### PR TITLE
Improved documentation around background images in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ You're also able to set a custom background image in the config. You can either 
   theme: "bento",
 
   // Place a background image in ./src/assets/images/ and provide the file name.
+  // If running in docker, ensure that you have a bind mount for `./src/assets/images:/src/src/assets/images`
   // Alternatively, provide a URL to an image. If the page is served over https, you may have issues loading images from insecure origins.
   // Set to "" to disable.
   backgroundImage: "", 

--- a/config.ts
+++ b/config.ts
@@ -31,6 +31,7 @@ export const config: Config = {
   theme: 'bento',
 
   // Place a background image in ./src/assets/images/ and provide the file name.
+  // If running in docker, ensure that you have a bind mount for `./src/assets/images:/src/src/assets/images`
   // Alternatively, provide a URL to an image. If the page is served over https, you may have issues loading images from insecure origins.
   // Set to "" to disable.
   backgroundImage: '',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       # Host path: Container path
       - ./config.ts:/src/config.ts
       - ./.env:/src/.env
+      # If using a locally-served background image, uncomment this line.
+      # Place the path to your images directory on the left
+      # - ./src/assets/images/:/src/src/assets/images/ 
     ports:
       # Replace host port 80 (left side) with desired port.
       - 80:8080


### PR DESCRIPTION
Added a (commented-out) default bind mount for the images directory

Added notes to config and readme on this being required